### PR TITLE
Add '*' option to select_range and a test to verify function; report error during test execution

### DIFF
--- a/anime_sama_api/cli/utils.py
+++ b/anime_sama_api/cli/utils.py
@@ -58,6 +58,10 @@ def select_range(choices: list[T], msg="Choose a range", print_choices=True) -> 
         return [choices[0]]
 
     def transform(string: str) -> list[T]:
+        # Return all choices if the user enter '*' symbol
+        if string == "*" :
+            return choices
+        # Else, detect the string and transform it into a list of choices
         ints_set: set[int] = set()
         for args in string.split(","):
             ints = [int(num) if num.strip() else None for num in args.split("-")]

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -51,6 +51,14 @@ def test_select_range(choices):
 
     assert select_range(choices) == ["abc", "def", 21, 5.2, "xyz"]
 
+def test_select_range_all_choices(choices):
+    utils.input_func = input_mock(["*"])
+    utils.print_func = print_mock(
+        print_choices + "[white]Choose a range[/white] [green][1-6][/]: \033[0;34m" * 6
+    )
+
+    assert select_range(choices) == choices
+
 
 def test_auto_select():
     utils.print_func = print_mock("-> [blue]1\n")


### PR DESCRIPTION
Sorry for the delay, but here’s the commit that adds the `*` option to the `select_range ` function along with a test to verify its functionality : `test_select_range_all_choices`.
When testing, I encountered the following error :
```
FAILED tests/test_cli_utils.py::test_select_range - AssertionError: assert ['def', 21, 5.2, 'xyz', 'abc'] == ['abc', 'def', 21, 5.2, 'xyz']
```
The full message :
```
_______________________________________________________________________________ test_select_range ________________________________________________________________________________

choices = ['abc', 'def', 21, 5.2, {1, 2, 3}, 'xyz']

    def test_select_range(choices):
        utils.input_func = input_mock(["abc", "1.2", "", "14", "1-4-5", "2-4, 6, 1"])
        utils.print_func = print_mock(
            print_choices + "[white]Choose a range[/white] [green][1-6][/]: \033[0;34m" * 6
        )

>       assert select_range(choices) == ["abc", "def", 21, 5.2, "xyz"]
E       AssertionError: assert ['def', 21, 5.2, 'xyz', 'abc'] == ['abc', 'def', 21, 5.2, 'xyz']
E
E         At index 0 diff: 'def' != 'abc'
E
E         Full diff:
E           [
E         -     'abc',
E               'def',...
E         
E         ...Full output truncated (5 lines hidden), use '-vv' to show

tests\test_cli_utils.py:52: AssertionError
```
I haven't modified this part of the function, so I'm not sure if this is a result of my changes or if it was already an existing issue.
Would you like me to investigate and fix this issue, or should I leave it as is for now ?