### PR TITLE
FIx the cases where the video has been deleted

### DIFF
--- a/anime_sama_api/cli/downloader.py
+++ b/anime_sama_api/cli/downloader.py
@@ -132,7 +132,12 @@ def download(
                     case "retry":
                         if retry_time >= max_retry_time:
                             break
-
+                        # Sometimes the player is valid, but the video has been deleted by the host.
+                        # The problem in this case is that it doesn't return an exception.
+                        # We assume that if, after 3 retries, the percentage still doesn't progress,
+                        # then we will switch to another player.
+                        if retry_time >= 3 and task.percentage == 0:
+                            break
                         logger.warning(
                             f"{episode.name} interrupted. Retrying in {retry_time}s."
                         )


### PR DESCRIPTION
This PR aims to fix a problem that I recently encountered. Some episodes on the Vidmoly player have been deleted, such as episode 1123 of One Piece. However, the URL remains valid, and only a retry error is returned. This is problematic because users cannot download the latest One Piece episodes unless they change the player in the configuration file.

My patch checks, after 3 retries, if the task percentage is equal to 0. If this is the case, it likely indicates that the video has been deleted, and it will switch to another player.